### PR TITLE
Nt/12 first tutorial interaction

### DIFF
--- a/Provoke/client/package-lock.json
+++ b/Provoke/client/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.5",
         "react-scripts": "5.0.1",
+        "react-tooltip": "^5.1.3",
         "reactstrap": "^9.1.5",
         "use-local-storage": "^2.3.6",
         "web-vitals": "^2.1.4"
@@ -2197,6 +2198,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.4.tgz",
+      "integrity": "sha512-FPFLbg2b06MIw1dqk2SOEMAMX3xlrreGjcui5OTxfBDtaKTmh0kioOVjT8gcfl58juawL/yF+S+gnq8aUYQx/Q=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.10.tgz",
+      "integrity": "sha512-ZRe5ZmtGYCd82zrjWnnMW8hN5H1otedLh0Ur6rRo6f0exbEe6IlkVvo1RO7tgiMvbF0Df8hkhdm50VcVYqwP6g==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.4"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -14347,6 +14361,19 @@
         }
       }
     },
+    "node_modules/react-tooltip": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.1.3.tgz",
+      "integrity": "sha512-taUR/Qk8RvQDq1pEET9kV7cHTmnAaGXg/pAOFA1GVfbEWtlTABLwVJPnDCOAFdtVBntGS1y7lS14fC+dNFX0uQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.4",
+        "classnames": "^2.3.2"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -18566,6 +18593,19 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
+      }
+    },
+    "@floating-ui/core": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.4.tgz",
+      "integrity": "sha512-FPFLbg2b06MIw1dqk2SOEMAMX3xlrreGjcui5OTxfBDtaKTmh0kioOVjT8gcfl58juawL/yF+S+gnq8aUYQx/Q=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.10.tgz",
+      "integrity": "sha512-ZRe5ZmtGYCd82zrjWnnMW8hN5H1otedLh0Ur6rRo6f0exbEe6IlkVvo1RO7tgiMvbF0Df8hkhdm50VcVYqwP6g==",
+      "requires": {
+        "@floating-ui/core": "^1.0.4"
       }
     },
     "@humanwhocodes/config-array": {
@@ -27233,6 +27273,15 @@
         "webpack-dev-server": "^4.6.0",
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
+      }
+    },
+    "react-tooltip": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.1.3.tgz",
+      "integrity": "sha512-taUR/Qk8RvQDq1pEET9kV7cHTmnAaGXg/pAOFA1GVfbEWtlTABLwVJPnDCOAFdtVBntGS1y7lS14fC+dNFX0uQ==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.4",
+        "classnames": "^2.3.2"
       }
     },
     "react-transition-group": {

--- a/Provoke/client/package.json
+++ b/Provoke/client/package.json
@@ -11,6 +11,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.5",
     "react-scripts": "5.0.1",
+    "react-tooltip": "^5.1.3",
     "reactstrap": "^9.1.5",
     "use-local-storage": "^2.3.6",
     "web-vitals": "^2.1.4"

--- a/Provoke/client/src/Components/drafts/Checkbox.js
+++ b/Provoke/client/src/Components/drafts/Checkbox.js
@@ -10,7 +10,7 @@ export const Checkbox = ( {label, checked} ) => {
                 <input type="checkbox" checked={isChecked} onChange={() => setIsChecked((prev) => !prev)} />
                 <span>{label}</span>
             </label>
-            <p className="checked-text"><i>{isChecked ? "Quote will publish with draft" : "Quote will not appear with draft"}</i></p>
+            {/* <p className="checked-text"><i>{isChecked ? "Quote will publish with draft" : "Quote will not appear with draft"}</i></p> */}
         </div>
     );
 };

--- a/Provoke/client/src/Components/drafts/TutorialDraft.js
+++ b/Provoke/client/src/Components/drafts/TutorialDraft.js
@@ -1,14 +1,27 @@
 //Renders a single published draft
+import { Tooltip } from "react-tooltip";
+
+
 
 export const TutorialDraft = ({ draftId, quote, author, title, content }) => {
     return (
         <>
         <div className="single-draft" key={draftId}>
-            <h3 className="tutorial-headline-styling">{title}</h3>
+            <h3 
+            id="published-title-element"
+            data-tooltip-content="This is the title you wrote. It was just a little while ago."
+            className="tutorial-headline-styling">{title}</h3>
+            <Tooltip 
+                anchorId="published-title-element" />
             <div className="tutorial-quote-card">
                 <div><i>{quote}</i> <b>-- {author}</b></div>
             </div>
-            <p className="tutorial-paragraph-styling">{content}</p>
+            <p 
+            id="published-content-element"
+            data-tooltip-content="WOW! This is what you wrote. You can emend or excise it if you're not pleased."
+            className="tutorial-paragraph-styling">{content}</p>
+            <Tooltip 
+                anchorId="published-content-element" />
 
         </div>
 

--- a/Provoke/client/src/Components/drafts/TutorialDraft.js
+++ b/Provoke/client/src/Components/drafts/TutorialDraft.js
@@ -9,10 +9,11 @@ export const TutorialDraft = ({ draftId, quote, author, title, content }) => {
         <div className="single-draft" key={draftId}>
             <h3 
             id="published-title-element"
-            data-tooltip-content="This is the title you wrote. It was just a little while ago."
+            data-tooltip-content="This is the title you wrote just a moment ago."
             className="tutorial-headline-styling">{title}</h3>
             <Tooltip 
-                anchorId="published-title-element" />
+                anchorId="published-title-element" 
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
             <div className="tutorial-quote-card">
                 <div><i>{quote}</i> <b>-- {author}</b></div>
             </div>
@@ -21,7 +22,8 @@ export const TutorialDraft = ({ draftId, quote, author, title, content }) => {
             data-tooltip-content="WOW! This is what you wrote. You can emend or excise it if you're not pleased."
             className="tutorial-paragraph-styling">{content}</p>
             <Tooltip 
-                anchorId="published-content-element" />
+                anchorId="published-content-element" 
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
 
         </div>
 

--- a/Provoke/client/src/Components/drafts/TutorialPublishedFeed.js
+++ b/Provoke/client/src/Components/drafts/TutorialPublishedFeed.js
@@ -15,10 +15,11 @@ export const TutorialPublishedFeed = ({ publishedDrafts }) => {
             <div className="tutorial-published-feed-column">
             <h1 
             id="browse-element"
-            data-tooltip-content="Look at all your posts! Use the scrollbar to see more of them."
+            data-tooltip-content="Look at all your posts! You can use the scrollbar!"
             className="tutorial-headline-styling">Browse</h1>
             <Tooltip 
-                anchorId="browse-element" />
+                anchorId="browse-element" 
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20" />
             <div className="tutorial-published-drafts-list">
                 {
                 publishedDrafts.map(
@@ -39,7 +40,8 @@ export const TutorialPublishedFeed = ({ publishedDrafts }) => {
                             Emend
                         </button>
                         <Tooltip 
-                anchorId="emend-button-element" />
+                anchorId="emend-button-element" 
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
                         <button 
                          id="excise-button-element"
                          data-tooltip-content="CLICK HERE TO EXCISE POST (that means 'Delete')"
@@ -47,7 +49,8 @@ export const TutorialPublishedFeed = ({ publishedDrafts }) => {
                             Excise
                         </button>
                         <Tooltip 
-                anchorId="excise-button-element" />
+                anchorId="excise-button-element" 
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
                     </div>                  
                     </> 
                 )

--- a/Provoke/client/src/Components/drafts/TutorialPublishedFeed.js
+++ b/Provoke/client/src/Components/drafts/TutorialPublishedFeed.js
@@ -1,15 +1,24 @@
 //this module creates the published drafts feed for the sidebar of NormalView.js
 import { useEffect, useState } from "react"
+import { useNavigate } from "react-router-dom"
 import { Button } from "./Button"
 import { TutorialDraft } from "./TutorialDraft"
+import { Tooltip } from "react-tooltip";
+
 
 export const TutorialPublishedFeed = ({ publishedDrafts }) => {
 
+    const navigate = useNavigate();
 
     return (
         <>
             <div className="tutorial-published-feed-column">
-            <h1 className="tutorial-headline-styling">Browse</h1>
+            <h1 
+            id="browse-element"
+            data-tooltip-content="Look at all your posts! Use the scrollbar to see more of them."
+            className="tutorial-headline-styling">Browse</h1>
+            <Tooltip 
+                anchorId="browse-element" />
             <div className="tutorial-published-drafts-list">
                 {
                 publishedDrafts.map(
@@ -23,12 +32,22 @@ export const TutorialPublishedFeed = ({ publishedDrafts }) => {
                     />
 
                     <div className="tutorial-button-div">
-                        <button className="tutorial-emend-button">
+                        <button 
+                        id="emend-button-element"
+                        data-tooltip-content="CLICK HERE TO EMEND POST (that means 'Edit')"
+                        className="tutorial-emend-button" onClick={() => navigate(`/editdraft/${draft.id}`)}>
                             Emend
                         </button>
-                        <button className="tutorial-excise-button">
+                        <Tooltip 
+                anchorId="emend-button-element" />
+                        <button 
+                         id="excise-button-element"
+                         data-tooltip-content="CLICK HERE TO EXCISE POST (that means 'Delete')"
+                        className="tutorial-excise-button" onClick={() => navigate(`/deletedraft/${draft.id}`)}>
                             Excise
                         </button>
+                        <Tooltip 
+                anchorId="excise-button-element" />
                     </div>                  
                     </> 
                 )

--- a/Provoke/client/src/Components/drafts/TutorialView.css
+++ b/Provoke/client/src/Components/drafts/TutorialView.css
@@ -167,3 +167,8 @@ textarea {
     border-radius: 4px;
     font-family: 'Comic Neue', cursive;
 }
+
+.tutorial-button-div {
+    display:flex;
+    justify-content: space-between;
+}

--- a/Provoke/client/src/Components/drafts/TutorialView.css
+++ b/Provoke/client/src/Components/drafts/TutorialView.css
@@ -102,6 +102,16 @@ textarea {
     border-radius: 4px; 
 }
 
+.tutorial-custom-red-button {
+    color: #131515;
+    background-color: #D81E5B;
+    border: none;
+    text-align: center;
+    font-size: 14px;
+    padding: 10px 24px;
+    border-radius: 4px; 
+}
+
 .tutorial-fieldset-post-form {
     border: none;
 }

--- a/Provoke/client/src/Components/drafts/TutorialView.js
+++ b/Provoke/client/src/Components/drafts/TutorialView.js
@@ -1,13 +1,16 @@
-import React from "react"
-import { useEffect, useState } from "react"
-import { addDraft, getAllPublishedDraftsByUser } from "../../Managers/DraftManager.js"
+import React from "react";
+import { Tooltip } from "react-tooltip";
+import { useEffect, useState } from "react";
+import { addDraft, getAllPublishedDraftsByUser } from "../../Managers/DraftManager.js";
 import { TutorialPublishedFeed } from "./TutorialPublishedFeed"
-import "./TutorialView.css"
-import { useParams } from "react-router-dom"
-import { getCurrentUser } from "../../Managers/UserManager.js"
-import { QuoteQueue } from "./QuoteQueue.js"
-import { getAllPlaceholders } from "../../Managers/PlaceholderManager.js"
-import { Checkbox } from "./Checkbox.js"
+import "./TutorialView.css";
+import { useParams } from "react-router-dom";
+import { getCurrentUser } from "../../Managers/UserManager.js";
+import { QuoteQueue } from "./QuoteQueue.js";
+import { getAllPlaceholders } from "../../Managers/PlaceholderManager.js";
+import { Checkbox } from "./Checkbox.js";
+import 'react-tooltip/dist/react-tooltip.css'
+
 
 export const TutorialView = () => {
     //something to send draft to updated published drafts sidebar
@@ -73,10 +76,38 @@ export const TutorialView = () => {
             published: "",
             placeholderId: ""}));
     }
+
+    const hideDraft = (e) => {
+        e.preventDefault();
+        const singleDraft = {
+            userId: user.id,
+            title: newDraft.title,
+            content: newDraft.content,
+            dateCreated: new Date(),
+            published: false,
+            placeholderId: oneQuote.id
+        }
+        addDraft(singleDraft)
+            .then(() => getAllPublishedDraftsByUser())
+            .then((draftArray) => { updatePublishedDrafts(draftArray)})
+            .then(() => updateNewDraft({        
+            userId: "",
+            title: "",
+            content: "",
+            dateCreated: "",
+            published: "",
+            placeholderId: ""}));
+    }
+
     return (
         <>
         <div className="tutorial-normal-body">
-            <div className="tutorial-create-post-form">
+            <div 
+            id="compose-form-element"
+            data-tooltip-content="Welcome to PROVOKE! Try creating your first post!"
+            className="tutorial-create-post-form">
+                <Tooltip 
+                anchorId="compose-form-element"/>
             <div className="tutorial-compose-header">
                 <h1 className="tutorial-headline-styling">Compose</h1>
                 <div className="tutorial-quote-card">
@@ -85,7 +116,11 @@ export const TutorialView = () => {
             </div>
             <fieldset className="tutorial-fieldset-post-form">
                 <div>
-                    <input className="tutorial-title-input" type="text" value={newDraft.title} 
+                    <h3 className="tutorial-headline-styling">Title</h3>
+                    <input 
+                    id="title-form-element"
+                    data-tooltip-content="People usually put a title here in this box!"
+                    className="tutorial-title-input" type="text" value={newDraft.title} 
                     onChange={
                         (evt) => {
                             const copy = { ...newDraft }
@@ -93,9 +128,18 @@ export const TutorialView = () => {
                             updateNewDraft(copy)
                         }
                     } />
+                    <Tooltip 
+                anchorId="title-form-element" />
                 </div>
                 <div>
-                    <textarea name="draft" required autoFocus type="text"
+                    <h3 
+                    id="content-form-element"
+                    data-tooltip-content="This is where your text goes! Try typing it!"
+                    className="tutorial-headline-styling">Draft</h3>
+                    <textarea 
+                    id="helpful-tip-element"
+                    data-tooltip-content="If you have forgotten how to type, visit www.typing.com to learn how!"
+                    name="draft" required autoFocus type="text"
                     className="tutorial-form-control" value={newDraft.content} onChange={
                         (evt) => {
                             const copy = { ... newDraft }
@@ -104,11 +148,26 @@ export const TutorialView = () => {
                         }
                     } />
                 </div>
+                    <Tooltip 
+                anchorId="content-form-element"/>
+                <Tooltip 
+                anchorId="helpful-tip-element"/>
 
                 <div className="tutorial-checkbox-button-span">
-                <Checkbox label="Dispose" checked={true} />
+                {/* <Checkbox label="Dispose" checked={true} /> */}
+                <button id="red-button-element"
+                data-tooltip-content="CLICK HERE TO CLEAR THIS FORM"
+                className="tutorial-custom-red-button" type="submit" onClick={handleSave}>Dispose</button>
+                <Tooltip 
+                anchorId="red-button-element" />
 
-                <button className="tutorial-custom-green-button" type="submit" onClick={handleSave}>Propose</button>
+                <button id="green-button-element"
+                data-tooltip-content="CLICK HERE TO PUBLISH YOUR DRAFT"
+                className="tutorial-custom-green-button" type="submit" onClick={hideDraft}
+                // data-tip data-for="registerTip"
+                >Propose</button>
+                <Tooltip 
+                anchorId="green-button-element" />
                 
                 </div>
             </fieldset>

--- a/Provoke/client/src/Components/drafts/TutorialView.js
+++ b/Provoke/client/src/Components/drafts/TutorialView.js
@@ -98,6 +98,7 @@ export const TutorialView = () => {
             published: "",
             placeholderId: ""}));
     }
+ 
 
     return (
         <>
@@ -107,7 +108,7 @@ export const TutorialView = () => {
             data-tooltip-content="Welcome to PROVOKE! Try creating your first post!"
             className="tutorial-create-post-form">
                 <Tooltip 
-                anchorId="compose-form-element"/>
+                anchorId="compose-form-element" style={{color:"aliceblue", backgroundColor:"red", fontFamily:"'Architects Daughter'"}}/>
             <div className="tutorial-compose-header">
                 <h1 className="tutorial-headline-styling">Compose</h1>
                 <div className="tutorial-quote-card">

--- a/Provoke/client/src/Components/drafts/TutorialView.js
+++ b/Provoke/client/src/Components/drafts/TutorialView.js
@@ -108,7 +108,7 @@ export const TutorialView = () => {
             data-tooltip-content="Welcome to PROVOKE! Try creating your first post!"
             className="tutorial-create-post-form">
                 <Tooltip 
-                anchorId="compose-form-element" style={{color:"aliceblue", backgroundColor:"red", fontFamily:"'Architects Daughter'"}}/>
+                anchorId="compose-form-element" style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
             <div className="tutorial-compose-header">
                 <h1 className="tutorial-headline-styling">Compose</h1>
                 <div className="tutorial-quote-card">
@@ -130,7 +130,8 @@ export const TutorialView = () => {
                         }
                     } />
                     <Tooltip 
-                anchorId="title-form-element" />
+                anchorId="title-form-element" 
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
                 </div>
                 <div>
                     <h3 
@@ -150,9 +151,11 @@ export const TutorialView = () => {
                     } />
                 </div>
                     <Tooltip 
-                anchorId="content-form-element"/>
+                anchorId="content-form-element"
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
                 <Tooltip 
-                anchorId="helpful-tip-element"/>
+                anchorId="helpful-tip-element"
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
 
                 <div className="tutorial-checkbox-button-span">
                 {/* <Checkbox label="Dispose" checked={true} /> */}
@@ -160,7 +163,8 @@ export const TutorialView = () => {
                 data-tooltip-content="CLICK HERE TO CLEAR THIS FORM"
                 className="tutorial-custom-red-button" type="submit" onClick={handleSave}>Dispose</button>
                 <Tooltip 
-                anchorId="red-button-element" />
+                anchorId="red-button-element" 
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
 
                 <button id="green-button-element"
                 data-tooltip-content="CLICK HERE TO PUBLISH YOUR DRAFT"
@@ -168,7 +172,8 @@ export const TutorialView = () => {
                 // data-tip data-for="registerTip"
                 >Propose</button>
                 <Tooltip 
-                anchorId="green-button-element" />
+                anchorId="green-button-element" 
+                style={{color:"#D81E5B", fontSize:"1rem", backgroundColor:"#E0FF4F", fontFamily:"'Press Start 2P', cursive", margin:"1rem"}} offset="20"/>
                 
                 </div>
             </fieldset>


### PR DESCRIPTION
This sets up tooltips for major affordances and main elements in the tutorial view (the "tutorial" element of the app). Styles tooltips and adjusts style on a few elements.

Also sets up the first set of pranks-- hide draft on "Propose" (when user believes they will be publishing) and publish draft on "Dispose" (when user believes they will be clearing a form).