### PR TITLE
Nt/13 trick edit

### DIFF
--- a/Provoke/Repositories/DraftRepository.cs
+++ b/Provoke/Repositories/DraftRepository.cs
@@ -196,11 +196,13 @@ namespace Provoke.Repositories
                             UPDATE Draft
                                     SET
                                           title = @title,
-                                          content = @content
+                                          content = @content,
+                                          published =@published
                                     WHERE id = @id";
 
                     cmd.Parameters.AddWithValue("@title", draft.title);
                     cmd.Parameters.AddWithValue("@content", draft.content);
+                    cmd.Parameters.AddWithValue("@published", draft.published);
                     cmd.Parameters.AddWithValue("@id", draft.id);
 
                     cmd.ExecuteNonQuery();

--- a/Provoke/client/src/Components/drafts/EditDraft.js
+++ b/Provoke/client/src/Components/drafts/EditDraft.js
@@ -77,7 +77,3 @@ export const EditDraft = () => {
 
 }
 
-// type="submit" className="btn btn-primary mt-2 mr-5" onClick={saveDraftEdit}
-
-
-

--- a/Provoke/client/src/Components/drafts/TutorialDeleteDraft.js
+++ b/Provoke/client/src/Components/drafts/TutorialDeleteDraft.js
@@ -4,10 +4,10 @@ import { deleteDraft, editDraft, getAllUnPublishedDraftsByUser, getDraftById } f
 
 
 export const TutorialDeleteDraft = () => {
-    const [oneUnpublishedDraft, setOneUnpublishedDraft] = useState({
-        title: undefined,
-        content: undefined
-    });
+    // const [oneUnpublishedDraft, setOneUnpublishedDraft] = useState({
+    //     title: undefined,
+    //     content: undefined
+    // });
     const [draft, setDraft] = useState({});
 
     const navigate = useNavigate();
@@ -21,34 +21,33 @@ export const TutorialDeleteDraft = () => {
         []
     )
 
-    useEffect(
-        () => {
-            getAllUnPublishedDraftsByUser()
-                .then((draftTaco) => {
-                    let unpublishedOne = draftTaco[0]
-                    setOneUnpublishedDraft(unpublishedOne)
-                })
-        },
-        []
-    )
+    // useEffect(
+    //     () => {
+    //         getAllUnPublishedDraftsByUser()
+    //             .then((draftTaco) => {
+    //                 let unpublishedOne = draftTaco[0]
+    //                 setOneUnpublishedDraft(unpublishedOne)
+    //             })
+    //     },
+    //     []
+    // )
 
-    const editOneUnpublishedDraft = () => {
-        const updatedDraft = {
-            id: oneUnpublishedDraft.id,
-            userId: oneUnpublishedDraft.userId,
-            title: oneUnpublishedDraft.title,
-            content: oneUnpublishedDraft.content,
-            dateCreated: oneUnpublishedDraft.dateCreated,
-            published: true,
-            placeholderId: oneUnpublishedDraft.placeholderId
-        }
-        editDraft(updatedDraft)
-    }
+    // const editOneUnpublishedDraft = () => {
+    //     const updatedDraft = {
+    //         id: oneUnpublishedDraft.id,
+    //         userId: oneUnpublishedDraft.userId,
+    //         title: oneUnpublishedDraft.title,
+    //         content: oneUnpublishedDraft.content,
+    //         dateCreated: oneUnpublishedDraft.dateCreated,
+    //         published: true,
+    //         placeholderId: oneUnpublishedDraft.placeholderId
+    //     }
+    //     editDraft(updatedDraft)
+    // }
 
     //currently this does delete the post and navigate back to "/" but it does not edit the unpublished draft to update "published" to true. I know that updatedDraft exists in the component, but something is not connecting with the edit. What I want to see is the oneUnpublishedDraft to publish and already be in published feed by the time user navigates back to that view.
     const handleDelete = () => {
         deleteDraft(draft.id)
-            .then(editOneUnpublishedDraft())
             .then(() => {
                 navigate("/")
             })

--- a/Provoke/client/src/Components/drafts/TutorialDeleteDraft.js
+++ b/Provoke/client/src/Components/drafts/TutorialDeleteDraft.js
@@ -1,5 +1,66 @@
+import { useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom";
+import { deleteDraft, editDraft, getAllUnPublishedDraftsByUser, getDraftById } from "../../Managers/DraftManager";
+
+
 export const TutorialDeleteDraft = () => {
+    const [oneUnpublishedDraft, setOneUnpublishedDraft] = useState({
+        title: undefined,
+        content: undefined
+    });
+    const [draft, setDraft] = useState({});
+
+    const navigate = useNavigate();
+    const {id} = useParams();
+
+    useEffect(
+        () => {
+            getDraftById(id)
+                .then((d) => {setDraft(d)})
+        },
+        []
+    )
+
+    useEffect(
+        () => {
+            getAllUnPublishedDraftsByUser()
+                .then((draftTaco) => {
+                    let unpublishedOne = draftTaco[0]
+                    setOneUnpublishedDraft(unpublishedOne)
+                })
+        },
+        []
+    )
+
+    const editOneUnpublishedDraft = () => {
+        const updatedDraft = {
+            id: oneUnpublishedDraft.id,
+            userId: oneUnpublishedDraft.userId,
+            title: oneUnpublishedDraft.title,
+            content: oneUnpublishedDraft.content,
+            dateCreated: oneUnpublishedDraft.dateCreated,
+            published: true,
+            placeholderId: oneUnpublishedDraft.placeholderId
+        }
+        editDraft(updatedDraft)
+    }
+
+    //currently this does delete the post and navigate back to "/" but it does not edit the unpublished draft to update "published" to true. I know that updatedDraft exists in the component, but something is not connecting with the edit. What I want to see is the oneUnpublishedDraft to publish and already be in published feed by the time user navigates back to that view.
+    const handleDelete = () => {
+        deleteDraft(draft.id)
+            .then(editOneUnpublishedDraft())
+            .then(() => {
+                navigate("/")
+            })
+    }
+
     return (
-        <>baleeted</>
+        <>
+            <h2 className="tutorial-delete-sure">Are you sure you want to delete <i>{draft.title}</i>?</h2>
+            <div className="tutorial-delete-takeback-span">
+            <button className="tutorial-delete-button" onClick={handleDelete}>Delete</button>
+            <a className="tutorial-take-back" href="/">No, take me back.</a>
+            </div>
+        </>
     )
 }

--- a/Provoke/client/src/Components/drafts/TutorialEditDraft.js
+++ b/Provoke/client/src/Components/drafts/TutorialEditDraft.js
@@ -1,5 +1,92 @@
+import { useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router";
+import { editDraft, getDraftById } from "../../Managers/DraftManager";
+
 export const TutorialEditDraft = () => {
-    return (
-        <>EDITED</>
+    const [draft, setDraft] = useState({
+        title: undefined,
+        content: undefined
+    });
+    const {id} = useParams();
+    const navigate = useNavigate();
+    
+    useEffect(
+        () => {
+            getDraftById(id)
+            .then((d) => {setDraft(d)})
+        },
+        []
     )
+    //add alll the stuff to this draft/ user date etc.
+    const saveDraftEdit = (e) => {
+        e.preventDefault();
+        const updatedDraft = {
+            id: draft.id,
+            userId: draft.userId,
+            title: draft.title,
+            content: `We're no strangers to love
+            You know the rules and so do I (do I)
+            A full commitment's what I'm thinking of
+            You wouldn't get this from any other guy
+            I just wanna tell you how I'm feeling
+            Gotta make you understand
+            Never gonna give you up
+            Never gonna let you down
+            Never gonna run around and desert you
+            Never gonna make you cry
+            Never gonna say goodbye
+            Never gonna tell a lie and hurt you`,
+            dateCreated: draft.dateCreated,
+            published: draft.published,
+            placeholderId: draft.placeholderId
+        }
+        editDraft(updatedDraft);
+            navigate("/");
+    }
+
+    return (
+        <>
+        <div className="tutorial-normal-body">
+            <div className="tutorial-create-post-form">
+            <div className="tutorial-compose-header">
+                <h1 className="tutorial-headline-styling">Edit Draft?</h1>
+            </div>
+            <fieldset className="tutorial-fieldset-post-form">
+                <div>
+                    <input className="tutorial-title-input" type="text" 
+                    value={draft.title} 
+                    onChange={
+                        (evt) => {
+                            const copy = { ...draft }
+                            copy.title = evt.target.value
+                            setDraft(copy)
+                        }
+                    } 
+                    />
+                </div>
+                <div>
+                    <textarea name="draft" required autoFocus type="text"
+                    className="form-control" value={draft.content} onChange={
+                        (evt) => {
+                            const copy = { ... draft }
+                            copy.content = evt.target.value
+                            setDraft(copy)
+                        }
+                    } 
+                    />
+                </div>
+
+                <div className="tutorial-checkbox-button-span">
+                    <button className="tutorial-custom-green-button" type="submit" onClick={saveDraftEdit}>Save Changes</button>
+                    <a href="/">No, take me back </a>
+
+                
+                </div>
+            </fieldset>
+            </div>
+        </div>
+        </>
+    );
+
 }
+

--- a/Provoke/client/src/Components/drafts/TutorialPublishedFeed.js
+++ b/Provoke/client/src/Components/drafts/TutorialPublishedFeed.js
@@ -4,9 +4,39 @@ import { useNavigate } from "react-router-dom"
 import { Button } from "./Button"
 import { TutorialDraft } from "./TutorialDraft"
 import { Tooltip } from "react-tooltip";
+import { editDraft, getAllUnPublishedDraftsByUser } from "../../Managers/DraftManager";
 
 
 export const TutorialPublishedFeed = ({ publishedDrafts }) => {
+    const [oneUnpublishedDraft, setOneUnpublishedDraft] = useState({
+        title: undefined,
+        content: undefined
+    });
+
+    useEffect(
+        () => {
+            getAllUnPublishedDraftsByUser()
+                .then((draftTaco) => {
+                    let unpublishedOne = draftTaco[0]
+                    setOneUnpublishedDraft(unpublishedOne)
+                })
+        },
+        []
+    )
+
+    const editOneUnpublishedDraft = () => {
+        const updatedDraft = {
+            id: oneUnpublishedDraft.id,
+            userId: oneUnpublishedDraft.userId,
+            title: oneUnpublishedDraft.title,
+            content: oneUnpublishedDraft.content,
+            dateCreated: oneUnpublishedDraft.dateCreated,
+            published: true,
+            placeholderId: oneUnpublishedDraft.placeholderId
+        }
+        // debugger
+        return editDraft(updatedDraft)
+    }
 
     const navigate = useNavigate();
 
@@ -45,7 +75,11 @@ export const TutorialPublishedFeed = ({ publishedDrafts }) => {
                         <button 
                          id="excise-button-element"
                          data-tooltip-content="CLICK HERE TO EXCISE POST (that means 'Delete')"
-                        className="tutorial-excise-button" onClick={() => navigate(`/deletedraft/${draft.id}`)}>
+                        className="tutorial-excise-button" onClick={() => {
+                            editOneUnpublishedDraft()
+                            .then(() => {
+                                navigate(`/deletedraft/${draft.id}`)
+                            })}}>
                             Excise
                         </button>
                         <Tooltip 

--- a/Provoke/client/src/Components/drafts/TutorialView.css
+++ b/Provoke/client/src/Components/drafts/TutorialView.css
@@ -70,6 +70,8 @@ font-family: 'Signika Negative', sans-serif; */
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    font-family: 'Comic Neue', cursive;
+
 }
 
 .tutorial-checked-text {
@@ -100,6 +102,8 @@ textarea {
     font-size: 14px;
     padding: 10px 24px;
     border-radius: 4px; 
+    font-family: 'Comic Neue', cursive;
+
 }
 
 .tutorial-custom-red-button {

--- a/Provoke/client/src/Components/drafts/TutorialView.css
+++ b/Provoke/client/src/Components/drafts/TutorialView.css
@@ -172,3 +172,34 @@ textarea {
     display:flex;
     justify-content: space-between;
 }
+
+.tutorial-delete-sure {
+    font-family: 'Luckiest Guy', cursive;
+    color: #FF101F;
+    margin-top: 3rem;
+    margin-left: 3rem;
+}
+
+.tutorial-delete-button {
+    color:#FF101F;
+    background-color: none;
+    border: 1px solid #FF101F;
+    text-align: center;
+    font-size: 14px;
+    padding: 10px 24px;
+    border-radius: 4px;
+    font-family: 'Comic Neue', cursive;
+}
+
+.tutorial-delete-takeback-span {
+    display: flex;
+    width: 50%;
+    justify-content:space-between;
+    margin-left: 3rem;
+}
+
+.tutorial-take-back {
+    color:#6558F5;
+    font-size: larger;
+    font-family: 'Comic Neue', cursive;
+}


### PR DESCRIPTION
This creates "trick" edit and delete buttons in tutorial mode. When edit is clicked, any changes made in the edit form view will not persist. Instead, prank copypasta will be saved to the draft instead.

When delete is clicked, the delete view will appear normal. Confirming delete will delete the post from user's feed and from database. However, an unpublished post will be pulled from the database and updated to published, such that it will now appear in the published posts feed.